### PR TITLE
outbox 수정 및 dlx 수정

### DIFF
--- a/src/main/java/com/emailagent/domain/entity/Outbox.java
+++ b/src/main/java/com/emailagent/domain/entity/Outbox.java
@@ -47,10 +47,6 @@ public class Outbox {
     @Builder.Default
     private int retryCount = 0;
 
-    @Column(name = "max_retry", nullable = false)
-    @Builder.Default
-    private int maxRetry = 5;
-
     @Column(name = "fail_reason", length = 500)
     private String failReason;
 
@@ -75,13 +71,19 @@ public class Outbox {
         this.finishedAt = LocalDateTime.now();
     }
 
-    public void markAsFailed(String reason) {
+    /** 발행 재시도 카운트 증가 (retry 판단은 Service 계층에서 수행) */
+    public void incrementRetryCount() {
         this.retryCount++;
-        if (this.retryCount >= this.maxRetry) {
-            this.status = OutboxStatus.FAILED;
-            this.failReason = reason;
-        } else {
-            this.status = OutboxStatus.READY; // 재시도 대기
-        }
+    }
+
+    /** 단순 READY 롤백 — 타임아웃 복구 시 retryCount 소모 없이 재투입 */
+    public void markAsReady() {
+        this.status = OutboxStatus.READY;
+    }
+
+    /** FAILED 확정 — 재시도 한도 초과 시 Service에서 판단 후 호출 */
+    public void markAsFailed(String reason) {
+        this.status = OutboxStatus.FAILED;
+        this.failReason = reason;
     }
 }

--- a/src/main/java/com/emailagent/rabbitmq/config/OutboxPolicy.java
+++ b/src/main/java/com/emailagent/rabbitmq/config/OutboxPolicy.java
@@ -1,0 +1,15 @@
+package com.emailagent.rabbitmq.config;
+
+/**
+ * Outbox 재시도 정책 상수.
+ *
+ * App → RabbitMQ 발행 실패 최대 재시도 횟수와
+ * AI 서버 → App 컨슈머 재시도 횟수를 단일 위치에서 관리한다.
+ */
+public final class OutboxPolicy {
+
+    /** App → RabbitMQ 발행 실패 / AI 컨슈머 처리 실패 공통 최대 재시도 횟수 */
+    public static final int MAX_RETRY = 3;
+
+    private OutboxPolicy() {}
+}

--- a/src/main/java/com/emailagent/rabbitmq/consumer/MailConsumer.java
+++ b/src/main/java/com/emailagent/rabbitmq/consumer/MailConsumer.java
@@ -1,5 +1,6 @@
 package com.emailagent.rabbitmq.consumer;
 
+import com.emailagent.rabbitmq.config.OutboxPolicy;
 import com.emailagent.rabbitmq.config.RabbitMQConfig;
 import com.emailagent.rabbitmq.dto.ClassifyResultDTO;
 import com.emailagent.rabbitmq.service.MailService;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -33,9 +35,9 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class MailConsumer {
 
-    private static final int MAX_RETRY_COUNT = 3;
 
     private final MailService mailService;
+    private final RabbitTemplate rabbitTemplate;
 
     @RabbitListener(
             queues = RabbitMQConfig.QUEUE_CLASSIFY_RESULT,
@@ -51,10 +53,12 @@ public class MailConsumer {
             // x-death 헤더에서 재시도 횟수 읽기
             int retryCount = extractRetryCount(message);
 
-            if (retryCount >= MAX_RETRY_COUNT) {
-                // 최대 재시도 초과 → FAILED 처리 후 ack (q.dlx.failed로 이동은 Terraform DLX 설정이 처리)
+            if (retryCount >= OutboxPolicy.MAX_RETRY) {
+                // 최대 재시도 초과 → FAILED 처리 후 원본 메시지를 q.dlx.failed에 수동 퍼블리시
+                // basicAck로 현재 큐에서 제거하고, RabbitTemplate으로 q.dlx.failed에 직접 전송
                 log.error("[MailConsumer] 최대 재시도 초과 → FAILED — outboxId={}, retryCount={}", outboxId, retryCount);
                 mailService.markFailed(outboxId, "Max retry exceeded: " + retryCount);
+                rabbitTemplate.send(RabbitMQConfig.QUEUE_DLX_FAILED, message);
                 channel.basicAck(deliveryTag, false);
                 return;
             }

--- a/src/main/java/com/emailagent/rabbitmq/service/MailServiceImpl.java
+++ b/src/main/java/com/emailagent/rabbitmq/service/MailServiceImpl.java
@@ -7,6 +7,7 @@ import com.emailagent.domain.enums.OutboxStatus;
 import com.emailagent.dto.response.admin.operation.AdminJobDetailResponse;
 import com.emailagent.dto.response.admin.operation.AdminJobListResponse;
 import com.emailagent.dto.response.admin.operation.AdminJobSummaryResponse;
+import com.emailagent.rabbitmq.config.OutboxPolicy;
 import com.emailagent.rabbitmq.dto.ClassifyResultDTO;
 import com.emailagent.rabbitmq.event.SseNotifyEvent;
 import com.emailagent.repository.EmailAnalysisResultRepository;
@@ -82,10 +83,19 @@ public class MailServiceImpl implements MailService {
     @Override
     @Transactional
     public void markPublishedFailed(Long outboxId) {
-        // Publisher Confirm ack=false → SENDING → READY 롤백 (브로커 미전달)
+        // Publisher Confirm ack=false → retryCount 증가 후 한도 초과 여부 판단
+        // retry 판단 로직은 Service 계층이 담당 (Outbox 엔티티는 상태 전이만 수행)
         outboxRepository.findById(outboxId).ifPresent(outbox -> {
-            log.warn("[MailService] Publisher Confirm 실패 — outboxId={}, READY로 롤백", outboxId);
-            outbox.markAsFailed("Publisher Confirm ack=false");
+            outbox.incrementRetryCount();
+            if (outbox.getRetryCount() >= OutboxPolicy.MAX_RETRY) {
+                log.error("[MailService] 발행 최대 재시도 초과 → FAILED — outboxId={}, retryCount={}",
+                        outboxId, outbox.getRetryCount());
+                outbox.markAsFailed("Publisher Confirm ack=false, max retry exceeded");
+            } else {
+                log.warn("[MailService] Publisher Confirm 실패 → READY 롤백 — outboxId={}, retryCount={}",
+                        outboxId, outbox.getRetryCount());
+                outbox.markAsReady();
+            }
         });
     }
 
@@ -146,12 +156,13 @@ public class MailServiceImpl implements MailService {
     @Override
     @Transactional
     public void resetTimedOut() {
-        // SENDING 상태가 30분 초과한 Outbox를 READY로 롤백
+        // SENDING 상태가 30분 초과한 Outbox를 READY로 단순 롤백
+        // retryCount를 소모하지 않음: 타임아웃은 발행 실패가 아닌 네트워크 지연 등 외부 요인이므로
         LocalDateTime timeout = LocalDateTime.now().minusMinutes(TIMEOUT_MINUTES);
         List<Outbox> timedOut = outboxRepository.findTimedOutMessages(timeout);
         timedOut.forEach(outbox -> {
             log.warn("[MailService] SENDING 타임아웃 → READY 롤백 — outboxId={}", outbox.getOutboxId());
-            outbox.markAsFailed("SENDING timeout " + TIMEOUT_MINUTES + "min");
+            outbox.markAsReady();
         });
     }
 
@@ -199,7 +210,7 @@ public class MailServiceImpl implements MailService {
                 outbox.getStatus().name(),
                 outbox.getPayload() != null ? outbox.getPayload().toString() : "",
                 outbox.getRetryCount(),
-                outbox.getMaxRetry(),
+                OutboxPolicy.MAX_RETRY,
                 outbox.getCreatedAt().toString(),
                 outbox.getSentAt() != null ? outbox.getSentAt().toString() : null,
                 outbox.getFinishedAt() != null ? outbox.getFinishedAt().toString() : null

--- a/src/main/java/com/emailagent/service/admin/AdminOperationService.java
+++ b/src/main/java/com/emailagent/service/admin/AdminOperationService.java
@@ -8,6 +8,7 @@ import com.emailagent.dto.response.admin.operation.AdminJobErrorResponse;
 import com.emailagent.dto.response.admin.operation.AdminJobListResponse;
 import com.emailagent.dto.response.admin.operation.AdminJobSummaryResponse;
 import com.emailagent.exception.ResourceNotFoundException;
+import com.emailagent.rabbitmq.config.OutboxPolicy;
 import com.emailagent.repository.OutboxRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -96,7 +97,7 @@ public class AdminOperationService {
                 outbox.getStatus().name(),
                 payloadJson,
                 outbox.getRetryCount(),
-                outbox.getMaxRetry(),
+                OutboxPolicy.MAX_RETRY,
                 outbox.getCreatedAt().toInstant(ZoneOffset.UTC).toString(),
                 sentAt,
                 finishedAt


### PR DESCRIPTION
1. 재시도 최대 정책이 OutboxEntity에 존재함 발견 -> 서비스 계층으로 옮김 + OutboxPolicy.java 생성해서 전역적으로 MAX_Retry 설정
2.  Outbox 컬럼에서 MAX_Retry 컬럼 삭제필요
3. Retry 횟수 3회 초과시 q.dlx.failed 로 publish 로직 추가